### PR TITLE
Dont kick players when starting a server

### DIFF
--- a/src/main/java/de/tubyoub/velocitypteropower/VelocityPteroPower.java
+++ b/src/main/java/de/tubyoub/velocitypteropower/VelocityPteroPower.java
@@ -385,8 +385,8 @@ public class VelocityPteroPower {
 
         } else {
             // Disconnect player (Limbo not configured, not registered, offline, or rate limited)
-            logger.info("Disconnecting player {} while server '{}' starts (Limbo not available/usable).", player.getUsername(), serverName);
             if(event.getPreviousServer() == null){
+                logger.info("Disconnecting player {} while server '{}' starts (Limbo not available/usable).", player.getUsername(), serverName);
                  player.disconnect(
                         Component.text(messagesManager.getMessage("starting-server-disconnect")
                                 .replace("%server%", serverName), NamedTextColor.WHITE));

--- a/src/main/java/de/tubyoub/velocitypteropower/VelocityPteroPower.java
+++ b/src/main/java/de/tubyoub/velocitypteropower/VelocityPteroPower.java
@@ -386,9 +386,15 @@ public class VelocityPteroPower {
         } else {
             // Disconnect player (Limbo not configured, not registered, offline, or rate limited)
             logger.info("Disconnecting player {} while server '{}' starts (Limbo not available/usable).", player.getUsername(), serverName);
-            player.disconnect(
-                    Component.text(messagesManager.getMessage("starting-server-disconnect")
-                            .replace("%server%", serverName), NamedTextColor.WHITE));
+            if(event.getPreviousServer() == null){
+                 player.disconnect(
+                        Component.text(messagesManager.getMessage("starting-server-disconnect")
+                                .replace("%server%", serverName), NamedTextColor.WHITE));
+            }else{
+                player.sendMessage(
+                        this.getPluginPrefix().append(Component.text(messagesManager.getMessage("starting-server-disconnect")
+                                .replace("%server%", serverName), NamedTextColor.AQUA)));
+            }
             event.setResult(ServerPreConnectEvent.ServerResult.denied());
         }
     }


### PR DESCRIPTION
There's no need to kick players if they are already in a lobby, this fixes it.

I also don't know if I should add a second log message or if the chat message should be aqua or white.