### PR TITLE
Fixed a typo in the whitelistreload command

### DIFF
--- a/src/main/java/de/tubyoub/velocitypteropower/command/PteroCommand.java
+++ b/src/main/java/de/tubyoub/velocitypteropower/command/PteroCommand.java
@@ -105,7 +105,7 @@ public class PteroCommand implements SimpleCommand {
                     sender.sendMessage(plugin.getPluginPrefix().append(Component.text(plugin.getMessagesManager().getMessage("no-permission"), TextColor.color(255, 0, 0))));
                 }
                 break;
-            case "reloadwhitelist":
+            case "whitelistreload":
                 if (configurationManager.getPanelType() == PanelType.mcServerSoft){
                     sender.sendMessage(plugin.getPluginPrefix().append(Component.text(plugin.getMessagesManager().getMessage("mcss-not-supported"), TextColor.color(255, 0, 0))));
                     break;


### PR DESCRIPTION
Fixed a typo in the whitelistreload command that caused a mismatch between the help message and the console command.