### PR TITLE
feat: don't power on servers that are under maintenance (kennytv/Maintenance hook)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,5 +181,13 @@
             <artifactId>adventure-text-minimessage</artifactId>
             <version>${minimessage.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>eu.kennytv.maintenance</groupId>
+            <artifactId>maintenance-api-proxy</artifactId>
+            <version>4.2.1</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/src/main/java/de/tubyoub/velocitypteropower/VelocityPteroPower.java
+++ b/src/main/java/de/tubyoub/velocitypteropower/VelocityPteroPower.java
@@ -126,7 +126,6 @@ public class VelocityPteroPower {
         }
 
         this.serverLifecycleManager = new ServerLifecycleManager(proxyServer, this);
-        MaintenanceHook.init(proxyServer, filteredLogger);
         this.playerConnectionHandler = new PlayerConnectionHandler(proxyServer, this);
         this.serverSwitchListener = new ServerSwitchListener(this, serverLifecycleManager);
         // Initialize and start lobby/limbo balancer
@@ -207,6 +206,7 @@ public class VelocityPteroPower {
                 commandManager.metaBuilder("ptero").aliases("vpp").build(), new PteroCommand(this));
         proxyServer.getEventManager().register(this, playerConnectionHandler);
         proxyServer.getEventManager().register(this, serverSwitchListener);
+        MaintenanceHook.init(this, proxyServer, filteredLogger);
 
         // Initialize bStats metrics and register custom charts
         this.metrics = metricsFactory.make(this, BSTATS_PLUGIN_ID);

--- a/src/main/java/de/tubyoub/velocitypteropower/VelocityPteroPower.java
+++ b/src/main/java/de/tubyoub/velocitypteropower/VelocityPteroPower.java
@@ -5,11 +5,13 @@ import com.velocitypowered.api.command.CommandManager;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
+import com.velocitypowered.api.plugin.Dependency;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import de.tubyoub.velocitypteropower.api.*;
 import de.tubyoub.velocitypteropower.command.PteroCommand;
+import de.tubyoub.velocitypteropower.hooks.MaintenanceHook;
 import de.tubyoub.velocitypteropower.handler.PlayerConnectionHandler;
 import de.tubyoub.velocitypteropower.lifecycle.ServerLifecycleManager;
 import de.tubyoub.velocitypteropower.listener.ServerSwitchListener;
@@ -40,7 +42,8 @@ import java.util.concurrent.ConcurrentHashMap;
         version = "0.9.5",
         authors = {"TubYoub"},
         description = "Manage Pterodactyl/Pelican/Mc Server Soft servers via Velocity.",
-        url = "https://github.com/Tubs-Pluginz/VelocityPteroPower")
+        url = "https://github.com/Tubs-Pluginz/VelocityPteroPower",
+        dependencies = {@Dependency(id = "maintenance", optional = true)})
 public class VelocityPteroPower {
     private static final String VERSION = "0.9.5";
     private static final String MODRINTH_PROJECT_ID = "1dDr5J4w";
@@ -123,6 +126,7 @@ public class VelocityPteroPower {
         }
 
         this.serverLifecycleManager = new ServerLifecycleManager(proxyServer, this);
+        MaintenanceHook.init(proxyServer, filteredLogger);
         this.playerConnectionHandler = new PlayerConnectionHandler(proxyServer, this);
         this.serverSwitchListener = new ServerSwitchListener(this, serverLifecycleManager);
         // Initialize and start lobby/limbo balancer

--- a/src/main/java/de/tubyoub/velocitypteropower/handler/PlayerConnectionHandler.java
+++ b/src/main/java/de/tubyoub/velocitypteropower/handler/PlayerConnectionHandler.java
@@ -10,6 +10,7 @@ import com.velocitypowered.api.proxy.server.RegisteredServer;
 import de.tubyoub.velocitypteropower.VelocityPteroPower;
 import de.tubyoub.velocitypteropower.api.PanelAPIClient;
 import de.tubyoub.velocitypteropower.api.PowerSignal;
+import de.tubyoub.velocitypteropower.hooks.MaintenanceHook;
 import de.tubyoub.velocitypteropower.manager.ConfigurationManager;
 import de.tubyoub.velocitypteropower.manager.MessageKey;
 import de.tubyoub.velocitypteropower.manager.MessagesManager;
@@ -61,6 +62,12 @@ public class PlayerConnectionHandler {
     Player player = event.getPlayer();
     RegisteredServer targetServer = event.getOriginalServer();
     String serverName = targetServer.getServerInfo().getName();
+
+    if (MaintenanceHook.isBlocked(player, serverName)) {
+      logger.debug("Not starting '{}' for {} — server is under maintenance.",
+              serverName, player.getUsername());
+      return;
+    }
 
     PteroServerInfo serverInfo = serverInfoMap.get(serverName);
     if (serverInfo == null) {

--- a/src/main/java/de/tubyoub/velocitypteropower/handler/PlayerConnectionHandler.java
+++ b/src/main/java/de/tubyoub/velocitypteropower/handler/PlayerConnectionHandler.java
@@ -15,6 +15,7 @@ import de.tubyoub.velocitypteropower.manager.ConfigurationManager;
 import de.tubyoub.velocitypteropower.manager.MessageKey;
 import de.tubyoub.velocitypteropower.manager.MessagesManager;
 import de.tubyoub.velocitypteropower.model.PteroServerInfo;
+import de.tubyoub.velocitypteropower.service.LimboReason;
 import de.tubyoub.velocitypteropower.util.RateLimitTracker;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
@@ -63,15 +64,16 @@ public class PlayerConnectionHandler {
     RegisteredServer targetServer = event.getOriginalServer();
     String serverName = targetServer.getServerInfo().getName();
 
-    if (MaintenanceHook.isBlocked(player, serverName)) {
-      logger.debug("Not starting '{}' for {} — server is under maintenance.",
-              serverName, player.getUsername());
-      return;
-    }
-
     PteroServerInfo serverInfo = serverInfoMap.get(serverName);
     if (serverInfo == null) {
       handleUnmanagedServer(player, serverName);
+      return;
+    }
+
+    if (MaintenanceHook.isBlocked(player, serverName)) {
+      logger.debug("Not starting '{}' for {} — server is under maintenance.",
+              serverName, player.getUsername());
+      handleMaintenanceBlocked(event, player, serverName);
       return;
     }
 
@@ -365,6 +367,36 @@ public class PlayerConnectionHandler {
       logger.debug("Balancer limbo selection failed: {}", ex.toString());
     }
     return Optional.empty();
+  }
+
+  private void handleMaintenanceBlocked(ServerPreConnectEvent event, Player player, String serverName) {
+    MaintenanceHook.markPending(player.getUniqueId(), serverName);
+
+    Optional<RegisteredServer> limboOpt = findValidLimboServer();
+    if (limboOpt.isEmpty()) {
+      return;
+    }
+    MaintenanceHook.consumePending(player.getUniqueId());
+
+    RegisteredServer limbo = limboOpt.get();
+    boolean alreadyOnLimbo = event.getPreviousServer() != null && event.getPreviousServer().equals(limbo);
+
+    if (alreadyOnLimbo) {
+      player.sendMessage(messagesManager.prefixed(MessageKey.CONNECT_SERVER_MAINTENANCE, "server", serverName));
+      event.setResult(ServerPreConnectEvent.ServerResult.denied());
+    } else {
+      if (event.getPreviousServer() != null) {
+        player.sendMessage(messagesManager.prefixed(MessageKey.CONNECT_MAINTENANCE_REDIRECT, "server", serverName, "limbo", limbo.getServerInfo().getName()));
+      }
+      event.setResult(ServerPreConnectEvent.ServerResult.allowed(limbo));
+    }
+
+    try {
+      var lts = plugin.getLimboTrackerService();
+      if (lts != null) {
+        lts.record(player, limbo, LimboReason.MAINTENANCE_WAIT, serverName);
+      }
+    } catch (Exception ignored) {}
   }
 
   private void scheduleDelayedConnect(

--- a/src/main/java/de/tubyoub/velocitypteropower/hooks/MaintenanceHook.java
+++ b/src/main/java/de/tubyoub/velocitypteropower/hooks/MaintenanceHook.java
@@ -1,0 +1,44 @@
+package de.tubyoub.velocitypteropower.hooks;
+
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import de.tubyoub.velocitypteropower.util.FilteredComponentLogger;
+import eu.kennytv.maintenance.api.Maintenance;
+import eu.kennytv.maintenance.api.MaintenanceProvider;
+import eu.kennytv.maintenance.api.proxy.MaintenanceProxy;
+import eu.kennytv.maintenance.api.proxy.Server;
+import java.util.Locale;
+
+public final class MaintenanceHook {
+    private static volatile MaintenanceProxy api;
+
+    private MaintenanceHook() {}
+
+    public static void init(ProxyServer proxy, FilteredComponentLogger logger) {
+        api = null;
+        if (!proxy.getPluginManager().isLoaded("maintenance")) return;
+
+        Maintenance m = MaintenanceProvider.get();
+        if (m instanceof MaintenanceProxy p) {
+            api = p;
+            logger.info("Maintenance plugin detected, hook enabled.");
+        } else {
+            logger.warn("Maintenance is loaded but its proxy API isn't available; hook disabled.");
+        }
+    }
+
+    public static boolean isBlocked(Player player, String serverName) {
+        MaintenanceProxy m = api;
+        if (m == null) return false;
+
+        boolean bypass = player.hasPermission("maintenance.admin") || player.hasPermission("maintenance.bypass") || m.getSettings().isWhitelisted(player.getUniqueId());
+
+        if (m.isMaintenance()) return !bypass;
+
+        Server server = m.getServer(serverName);
+        if (server == null || !m.isMaintenance(server)) return false;
+
+        return !bypass && !player.hasPermission("maintenance.singleserver.bypass." + server.getName().toLowerCase(Locale.ROOT));
+
+    }
+}

--- a/src/main/java/de/tubyoub/velocitypteropower/hooks/MaintenanceHook.java
+++ b/src/main/java/de/tubyoub/velocitypteropower/hooks/MaintenanceHook.java
@@ -2,29 +2,73 @@ package de.tubyoub.velocitypteropower.hooks;
 
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import de.tubyoub.velocitypteropower.VelocityPteroPower;
+import de.tubyoub.velocitypteropower.service.LimboReason;
+import de.tubyoub.velocitypteropower.service.LimboTrackerService;
+import de.tubyoub.velocitypteropower.service.PlayerLimboRecord;
 import de.tubyoub.velocitypteropower.util.FilteredComponentLogger;
+
 import eu.kennytv.maintenance.api.Maintenance;
 import eu.kennytv.maintenance.api.MaintenanceProvider;
+import eu.kennytv.maintenance.api.event.MaintenanceChangedEvent;
+import eu.kennytv.maintenance.api.event.proxy.ServerMaintenanceChangedEvent;
 import eu.kennytv.maintenance.api.proxy.MaintenanceProxy;
 import eu.kennytv.maintenance.api.proxy.Server;
-import java.util.Locale;
+import eu.kennytv.maintenance.api.event.manager.EventListener;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class MaintenanceHook {
     private static volatile MaintenanceProxy api;
+    private static volatile VelocityPteroPower plugin;
+    private static volatile ProxyServer proxy;
+    private static volatile FilteredComponentLogger logger;
+    private static volatile boolean listenersRegistered;
+    private static final Map<UUID, String> PENDING_TARGETS = new ConcurrentHashMap<>();
+
 
     private MaintenanceHook() {}
 
-    public static void init(ProxyServer proxy, FilteredComponentLogger logger) {
+    public static void init(VelocityPteroPower pluginInstance, ProxyServer proxyServer, FilteredComponentLogger log) {
         api = null;
+        plugin = pluginInstance;
+        proxy = proxyServer;
+        logger = log;
+
         if (!proxy.getPluginManager().isLoaded("maintenance")) return;
 
         Maintenance m = MaintenanceProvider.get();
-        if (m instanceof MaintenanceProxy p) {
-            api = p;
-            logger.info("Maintenance plugin detected, hook enabled.");
-        } else {
+        if (!(m instanceof MaintenanceProxy p)) {
             logger.warn("Maintenance is loaded but its proxy API isn't available; hook disabled.");
+            return;
         }
+        api = p;
+
+        if (!listenersRegistered) {
+            p.getEventManager().registerListener(
+                    new EventListener<MaintenanceChangedEvent>() {
+                        @Override
+                        public void onEvent(MaintenanceChangedEvent event) {
+                            if (!event.isMaintenance()) retryWaiting(null);
+                        }
+                    },
+                    MaintenanceChangedEvent.class);
+
+            p.getEventManager().registerListener(
+                    new EventListener<ServerMaintenanceChangedEvent>() {
+                        @Override
+                        public void onEvent(ServerMaintenanceChangedEvent event) {
+                            if (!event.isMaintenance()) retryWaiting(event.getServer().getName());
+                        }
+                    },
+                    ServerMaintenanceChangedEvent.class);
+            listenersRegistered = true;
+        }
+
+        log.info("Maintenance plugin detected, hook enabled.");
     }
 
     public static boolean isBlocked(Player player, String serverName) {
@@ -33,12 +77,74 @@ public final class MaintenanceHook {
 
         boolean bypass = player.hasPermission("maintenance.admin") || player.hasPermission("maintenance.bypass") || m.getSettings().isWhitelisted(player.getUniqueId());
 
-        if (m.isMaintenance()) return !bypass;
+        if (m.isMaintenance() && !bypass) return true;
 
         Server server = m.getServer(serverName);
         if (server == null || !m.isMaintenance(server)) return false;
 
         return !bypass && !player.hasPermission("maintenance.singleserver.bypass." + server.getName().toLowerCase(Locale.ROOT));
 
+    }
+
+    private static void retryWaiting(String changedServer) {
+        VelocityPteroPower pl = plugin;
+        ProxyServer p = proxy;
+        if (pl == null || p == null) return;
+
+        LimboTrackerService lts = pl.getLimboTrackerService();
+        if (lts == null) return;
+
+        p.getScheduler().buildTask(pl, () -> {
+            List<PlayerLimboRecord> records = lts.all();
+            for (PlayerLimboRecord record : records) {
+                if (record.getReason() != LimboReason.MAINTENANCE_WAIT) continue;
+
+                String target = record.getContext();
+                if (target == null || target.isBlank()) continue;
+                if (changedServer != null && !changedServer.equalsIgnoreCase(target)) continue;
+
+                Optional<Player> maybePlayer = p.getPlayer(record.getPlayerId());
+                if (maybePlayer.isEmpty()) {
+                    lts.clearForPlayer(record.getPlayerId(), "offline during maintenance retry");
+                    continue;
+                }
+                Player player = maybePlayer.get();
+
+                if (isBlocked(player, target)) continue;
+
+                Optional<RegisteredServer> maybeServer = p.getServer(target);
+                if (maybeServer.isEmpty()) {
+                    lts.clearForPlayer(record.getPlayerId(), "target '" + target + "' not registered");
+                    continue;
+                }
+
+                if (logger != null) {
+                    logger.info("Maintenance lifted for '{}', re-requesting connection for {}.", target, player.getUsername());
+                }
+
+                player.createConnectionRequest(maybeServer.get()).connect().whenComplete((result, throwable) -> {
+                    if (throwable != null && logger != null) {
+                        logger.debug("Maintenance retry for {} -> {} failed: {}", player.getUsername(), target, throwable.toString());
+                    }
+                });
+            }
+
+
+        }).delay(Duration.ofMillis(500)).schedule();
+    }
+
+    public static boolean isServerUnderMaintenance(String serverName) {
+        MaintenanceProxy m = api;
+        if (m == null) return false;
+        Server server = m.getServer(serverName);
+        return server != null && m.isMaintenance(server);
+    }
+
+    public static void markPending(UUID uuid, String target) {
+        PENDING_TARGETS.put(uuid, target);
+    }
+
+    public static String consumePending(UUID uuid) {
+        return PENDING_TARGETS.remove(uuid);
     }
 }

--- a/src/main/java/de/tubyoub/velocitypteropower/listener/ServerSwitchListener.java
+++ b/src/main/java/de/tubyoub/velocitypteropower/listener/ServerSwitchListener.java
@@ -3,13 +3,16 @@ package de.tubyoub.velocitypteropower.listener;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.player.ServerConnectedEvent;
+import com.velocitypowered.api.event.player.ServerPostConnectEvent;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import de.tubyoub.velocitypteropower.VelocityPteroPower;
+import de.tubyoub.velocitypteropower.hooks.MaintenanceHook;
 import de.tubyoub.velocitypteropower.lifecycle.ServerLifecycleManager;
 import de.tubyoub.velocitypteropower.manager.MessageKey;
 import de.tubyoub.velocitypteropower.manager.MessagesManager;
 import de.tubyoub.velocitypteropower.model.PteroServerInfo;
+import de.tubyoub.velocitypteropower.service.LimboReason;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 
 import java.util.concurrent.TimeUnit;
@@ -32,7 +35,7 @@ public class ServerSwitchListener {
   public void onDisconnect(DisconnectEvent event) {
     Player player = event.getPlayer();
     // Cleanup limbo record on disconnect
-    try { var lts = plugin.getLimboTrackerService(); if (lts != null) lts.clearForPlayer(player.getUniqueId(), "disconnect"); } catch (Exception ignored) {}
+    try { var lts = plugin.getLimboTrackerService(); if (lts != null) lts.clearForPlayer(player.getUniqueId(), "disconnect"); MaintenanceHook.consumePending(player.getUniqueId()); } catch (Exception ignored) {}
 
     // Record move history: current -> DISCONNECT
     try {
@@ -81,7 +84,18 @@ public class ServerSwitchListener {
         boolean joinedLimbo = cfg.getBalancerLimbos() != null && cfg.getBalancerLimbos().contains(newServerName);
         if (joinedLimbo) {
           if (lts.get(event.getPlayer().getUniqueId()).isEmpty()) {
-            lts.recordSelfMove(event.getPlayer(), newServer);
+            String pendingTarget = MaintenanceHook.consumePending(event.getPlayer().getUniqueId());
+            String previousName = event.getPreviousServer()
+                    .map(ps -> ps.getServerInfo().getName())
+                    .orElse(null);
+
+            if (pendingTarget != null) {
+              lts.record(event.getPlayer(),newServer, LimboReason.MAINTENANCE_WAIT, pendingTarget);
+            } else if (previousName != null && MaintenanceHook.isServerUnderMaintenance(previousName)) {
+              lts.record(event.getPlayer(), newServer, LimboReason.MAINTENANCE_WAIT, previousName);
+            } else {
+              lts.recordSelfMove(event.getPlayer(), newServer);
+            }
           }
         }
       }
@@ -117,4 +131,24 @@ public class ServerSwitchListener {
               }
             });
   }
+
+  @Subscribe
+  public void onServerPostConnect(ServerPostConnectEvent event) {
+    if (event.getPreviousServer() != null) return;
+
+    try {
+      var lts = plugin.getLimboTrackerService();
+      if (lts == null) return;
+
+      lts.get(event.getPlayer().getUniqueId()).ifPresent(record -> {
+        if (record.getReason() != LimboReason.MAINTENANCE_WAIT) return;
+
+        String target = record.getContext();
+        if (target == null || target.isBlank()) return;
+
+        event.getPlayer().sendMessage(messages.prefixed(MessageKey.CONNECT_MAINTENANCE_REDIRECT, "server", target, "limbo", record.getLimboServer()));
+      });
+    } catch (Exception ignored) {}
+  }
+
 }

--- a/src/main/java/de/tubyoub/velocitypteropower/manager/MessageKey.java
+++ b/src/main/java/de/tubyoub/velocitypteropower/manager/MessageKey.java
@@ -45,6 +45,8 @@ public enum MessageKey {
     CONNECT_TARGET_SERVER_NOT_FOUND("connect.target-server-not-found"),
     CONNECT_NOT_WHITELISTED("connect.not-whitelisted"),
     CONNECT_MAX_ONLINE_REACHED("connect.max-online-reached"),
+    CONNECT_SERVER_MAINTENANCE("connect.server-maintenance"),
+    CONNECT_MAINTENANCE_REDIRECT("connect.maintenance-redirect"),
 
     // Server lifecycle
     SERVER_STARTING("server.starting"),

--- a/src/main/java/de/tubyoub/velocitypteropower/service/LimboReason.java
+++ b/src/main/java/de/tubyoub/velocitypteropower/service/LimboReason.java
@@ -15,6 +15,11 @@ public enum LimboReason {
     SELF_MOVE,
 
     /**
+     * The player's requested server is under maintenance; waiting for it to be lifted.
+     */
+    MAINTENANCE_WAIT,
+
+    /**
      * Any other plugin/external reason.
      */
     OTHER

--- a/src/main/resources/messages/de_DE.yml
+++ b/src/main/resources/messages/de_DE.yml
@@ -43,6 +43,8 @@ connect:
   target-server-not-found: "<red>Zielserver '<server>' ist nicht verfügbar.</red>"
   not-whitelisted: "<red>Du bist auf diesem Server nicht auf der Whitelist.</red>"
   max-online-reached: "<red>Server kann nicht gestartet werden.</red> <gray>Maximale Anzahl gleichzeitig laufender Server erreicht (</gray><yellow><max></yellow><gray>).</gray>"
+  server-maintenance: "<red>Server '<server>' befindet sich in Wartung.</red>"
+  maintenance-redirect: "<gray>Server '<server>' befindet sich in Wartung. Du wirst zu</gray> <aqua><limbo></aqua> <gray>gesendet...</gray>"
 
 server:
   starting: "<gray>Server startet...</gray>"

--- a/src/main/resources/messages/en_US.yml
+++ b/src/main/resources/messages/en_US.yml
@@ -42,7 +42,9 @@ connect:
   start-timeout: "<red>Server '<server>' did not start in time.</red>"
   target-server-not-found: "<red>Target server '<server>' is not available.</red>"
   not-whitelisted: "<red>You are not whitelisted on this server.</red>"
-  max-online-reached: "<red>Cannot start server.</red> <gray>Maximum number of online servers reached (</gray><yellow><max></yellow><gray>).</gray>" 
+  max-online-reached: "<red>Cannot start server.</red> <gray>Maximum number of online servers reached (</gray><yellow><max></yellow><gray>).</gray>"
+  server-maintenance: "<red>Server '<server>' is under maintenance.</red>"
+  maintenance-redirect: "<gray>Server '<server>' is under maintenance. Sending you to</gray> <aqua><limbo></aqua><gray>...</gray>"
 
 server:
   starting: "<gray>Server is starting...</gray>"


### PR DESCRIPTION
Adds an optional integration with [kennytv/Maintenance](https://github.com/kennytv/Maintenance) so VPP doesn't start a server that's flagged for maintenance.

Currently, when a player joins a server under maintenance, VPP sees the connect attempt, powers the server on, and holds the connection. When the server is up, maintenance denies the join attempt. The server needlessly boots in this situation.

This hook allows VPP to check the maintenance state first, skip power-on, send the player to limbo, and automatically return them when maintenance is lifted.

This functionality is fully optional, and the hook is inert when Maintenance isn't installed.
